### PR TITLE
feat(schema): Phase 2/3 stubs + utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,10 @@ Accessibility & Inclusivity
 
 Notes
 - This is scaffolded without installing dependencies. Choose your package manager and initialize per app.
+
+Schema readiness for future phases
+- packages/content/src/schema/people.json provides birthdays for dynamic age math.
+- packages/content/src/schema/events.json anchors comparisons to real dates.
+- packages/content/src/schema/templates.json includes Phase‑2/3 entries (ask_age_compare, ask_age_at_when_sienna, ask_age_at_event).
+- packages/content/src/schema/options.json contains multi‑select and sequenced steps to drive the wizard.
+These are inert until UI routes use them; Phase‑1 behavior is unchanged.

--- a/docs/PROJECT_OVERVIEW_PICO.md
+++ b/docs/PROJECT_OVERVIEW_PICO.md
@@ -1,0 +1,134 @@
+# Sienna – Project Overview (Pico + Motion) – 2025-08-29–1610
+(from ChatGPT)
+
+## Purpose
+A calm, step-by-step AAC app that helps Sienna build clear messages with minimal cognitive load. Predictable layouts, large tap targets, and optional gentle motion.
+
+## Tech Stance (Phase 1)
+- **Framework:** Vanilla HTML/JS (or Vite Vanilla) for prototype; React later.
+- **UI:** **Pico.css** (tokens via CSS variables) + **Motion One** for micro-interactions.
+- **Data:** Schema-first JSON (categories, templates, options).
+- **A11y:** High contrast themes, large targets, respect `prefers-reduced-motion`.
+
+## Why Pico + Motion (not Tailwind/shadcn) now
+- Tiny footprint, quick to theme, great defaults for large touch surfaces.
+- We own the visual language; no fighting a component library.
+- We can add shadcn selectively in Phase 2+ for Dialog/Sheet/Select if needed.
+
+## Style Tokens (base theme)
+- clay `#CC6A4C` (primary) · gold `#93784E` (surface-2) · cream `#F7E4D2` (bg)
+- charcoal `#161614` (text) · offwhite `#FFFBF4` (cards/sticky)
+- Corners 24px · Shadow `0 8px 24px rgba(22,22,20,0.06)`
+- Type: **Prata** (serif headings), **Inter** (body/buttons). Body 18–20px.
+
+## Themes
+- `sienna-default` (above tokens)
+- `sienna-contrast` (stronger contrast)
+- `sienna-playful` (soft rose/lilac, still calm)
+HTML attribute drives theme: `<html data-theme="sienna-default">`. CSS maps `--pico-*` vars to our theme vars.
+
+## Motion Rules (Motion One)
+- Page enter: fade + 12px slide (220ms, ease-out), motion-safe.
+- Card/Button press: scale 0.98 on down/1.0 on up (150ms).
+- Sticky bar “bump” to 1.02 on token add (180ms).
+- Disable animations if `prefers-reduced-motion: reduce`.
+
+
+---
+
+## Information Architecture
+
+The app is organized into a simple step-by-step wizard, with a sticky sentence bar at the top and footer navigation (Back · Main Menu) at the bottom. This structure ensures predictable navigation, large touch targets, and minimal cognitive load.
+
+### Phase 1 – Core Flows
+
+1. **Main Menu**
+
+   * Layout: 2×2 grid (scrollable if more options are added later).
+   * Starter categories: *How I Feel*, *Ask Something*, *I Want To*, *Quick Chat*.
+   * Categories are customizable by caregivers. “Favorites” can float to the top.
+
+2. **How I Feel**
+
+   * Template: “I feel {emotion}.”
+   * Six starter emotions (happy, tired, loved, frustrated, excited, nervous).
+   * Customizable list, with parent/guardian lock to prevent accidental edits.
+
+3. **Ask Something**
+
+   * Phase 1 scope: single person, current age (e.g., “How old is Mommy?”).
+   * Template system: `{question} {subject}`.
+   * Confirm & Send after one selection.
+
+4. **Sticky Sentence Bar**
+
+   * Always visible.
+   * Shows sentence tokens being built.
+   * Includes Undo (remove last token) and Reset (clear all).
+
+5. **Footer Navigation**
+
+   * Back (step back one screen).
+   * Main Menu (reset + return).
+
+---
+
+### Phase 2 – Comparisons
+
+* Add “+ Add another person” in Ask flows.
+* Example: “Mommy is 39. Daddy is 41. Chad Wild Clay is 41.”
+* Schema update: templates accept arrays of subjects.
+
+---
+
+### Phase 3 – Time Anchors
+
+* Add optional “at what time?” step.
+* Choices:
+
+  * “Today” (default).
+  * “When Sienna was {age}.”
+  * “On event {name} (with stored date).”
+* Backend calculates ages by subtracting birthdates from event date.
+* Schema update: `events.json` file for concerts, shows, milestones.
+
+---
+
+### Phase 4 – Visual Timelines
+
+* Add simple timeline visualization: horizontal bar chart or stacked cards.
+* Shows side-by-side ages at chosen date/event.
+* Helps reinforce developmental concept that parents were once younger too.
+
+---
+
+This keeps **Phase 1 extremely lightweight** (one-person age lookups, emotions, basic sentences) while laying the foundation for comparison, events, and timelines later. Each phase is additive — schema-first design ensures no rewrites.
+
+---
+
+
+## Schema (JSON)
+- `categories.json` – top-level options
+- `templates.json` – sentence patterns (arrays like `["How old is", "{person}"]`)
+- `options.json` – choice sets keyed by template step (e.g., `choose_person`)
+
+## Component Primitives (Phase 1)
+- `StickySentenceBar` (offwhite pill, actions: Undo/Reset)
+- `CategoryCard` (offwhite card, large tap target)
+- `OptionButton` (large, offwhite or clay variant)
+- `FooterNav` (gold surface)
+
+## Roadmap
+- **Phase 1:** Pico + Motion prototype (no LLM). Confirm flows and ergonomics on device.
+- **Phase 2:** Personalization (family, favorites, ages); optional shadcn for Dialog/Sheet/Select.
+- **Phase 3:** TTS preview; restricted contacts for messaging; Save Favorites.
+- **Phase 4:** LLM add-on (events, lookups, preferences) with caregiver-controlled scope.
+
+## Repo Alignment (update plan)
+- Root README: keep monorepo description; add Pico/Motion as Phase-1 UI choice.
+- `docs/NEXT_STEPS.md`: replace Tailwind/Shadcn with Pico/Motion for Phase 1.
+- `apps/chat/README.md`: set “Pico + Motion” as starter; React later.
+- `docs/ACCESSIBILITY.md`: keep as-is (good).
+- Keep `docs/PROJECTS.md` as-is for project automation.
+
+

--- a/packages/content/src/schema/events.json
+++ b/packages/content/src/schema/events.json
@@ -1,0 +1,9 @@
+{
+  "$meta": { "version": 1, "updated": "2025-08-29" },
+  "events": [
+    { "id": "kidz-bop-2012", "label": "Kidz Bop Concert (2012)", "date": "2012-08-12" },
+    { "id": "kidz-bop-2018", "label": "Kidz Bop Concert (2018)", "date": "2018-07-20" },
+    { "id": "first-shrek-musical", "label": "First Shrek Musical", "date": "2023-10-14" }
+  ]
+}
+

--- a/packages/content/src/schema/options.json
+++ b/packages/content/src/schema/options.json
@@ -1,0 +1,25 @@
+{
+  "$meta": { "version": 2, "updated": "2025-08-29" },
+  "choose_people": {
+    "type": "dynamic",
+    "source": "people",
+    "select": "multi",
+    "min": 1,
+    "max": 6
+  },
+  "choose_people_then_years": {
+    "type": "sequence",
+    "steps": [
+      { "id": "choose_people", "type": "dynamic", "source": "people", "select": "multi", "min": 1, "max": 6 },
+      { "id": "choose_years", "type": "range", "min": 0, "max": 50, "step": 1, "label": "Years old" }
+    ]
+  },
+  "choose_people_then_event": {
+    "type": "sequence",
+    "steps": [
+      { "id": "choose_people", "type": "dynamic", "source": "people", "select": "multi", "min": 1, "max": 6 },
+      { "id": "choose_event", "type": "dynamic", "source": "events", "select": "single" }
+    ]
+  }
+}
+

--- a/packages/content/src/schema/people.json
+++ b/packages/content/src/schema/people.json
@@ -1,0 +1,11 @@
+{
+  "$meta": { "version": 1, "updated": "2025-08-29" },
+  "people": [
+    { "id": "sienna", "label": "You (S)", "birthDate": "2011-06-15" },
+    { "id": "mommy", "label": "Mommy", "birthDate": "1986-03-22" },
+    { "id": "daddy", "label": "Daddy", "birthDate": "1984-11-05" },
+    { "id": "cwc", "label": "Chad Wild Clay", "birthDate": "1984-03-10" },
+    { "id": "vyq", "label": "Vy Qwaint", "birthDate": "1986-01-03" }
+  ]
+}
+

--- a/packages/content/src/schema/templates.json
+++ b/packages/content/src/schema/templates.json
@@ -1,0 +1,33 @@
+{
+  "$meta": { "version": 2, "updated": "2025-08-29" },
+  "templates": [
+    {
+      "id": "ask_age_compare",
+      "category": "ask",
+      "pattern": ["How old are", "{people[]}"],
+      "next": "choose_people",
+      "output": "list",
+      "phase": 2,
+      "description": "Compare ages for multiple selected people (today)."
+    },
+    {
+      "id": "ask_age_at_when_sienna",
+      "category": "ask",
+      "pattern": ["How old were", "{people[]}", "when Sienna was", "{years}"],
+      "next": "choose_people_then_years",
+      "output": "list",
+      "phase": 3,
+      "description": "Compute ages of people when Sienna was N years old."
+    },
+    {
+      "id": "ask_age_at_event",
+      "category": "ask",
+      "pattern": ["How old were", "{people[]}", "on", "{event}"],
+      "next": "choose_people_then_event",
+      "output": "list",
+      "phase": 3,
+      "description": "Compute ages of people on a specific event date."
+    }
+  ]
+}
+

--- a/packages/utils/src/age.ts
+++ b/packages/utils/src/age.ts
@@ -1,0 +1,23 @@
+export function yearsBetween(dateISO: string, anchorISO: string): number {
+  const dob = new Date(dateISO);
+  const at = new Date(anchorISO);
+  if (isNaN(dob.getTime()) || isNaN(at.getTime())) return NaN;
+  let years = at.getFullYear() - dob.getFullYear();
+  const m = at.getMonth() - dob.getMonth();
+  if (m < 0 || (m === 0 && at.getDate() < dob.getDate())) years--;
+  return years;
+}
+
+export function todayISO(): string {
+  const d = new Date();
+  return d.toISOString().slice(0, 10);
+}
+
+export function dateWhenSiennaWasN(siennaBirthISO: string, nYears: number): string {
+  const dob = new Date(siennaBirthISO);
+  if (isNaN(dob.getTime())) return "";
+  const anchor = new Date(dob);
+  anchor.setFullYear(dob.getFullYear() + nYears);
+  return anchor.toISOString().slice(0, 10);
+}
+

--- a/packages/utils/src/flags.ts
+++ b/packages/utils/src/flags.ts
@@ -1,0 +1,4 @@
+export const flags = {
+  caregiverMode: false,
+};
+

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -13,3 +13,5 @@ export const a11y = {
     typeof window !== 'undefined' && window.matchMedia?.('(prefers-reduced-motion: reduce)').matches,
 };
 
+export * from './age';
+export * from './flags';


### PR DESCRIPTION
Adds schema stubs and utilities for upcoming Phases 2 and 3.

- packages/content/src/schema/people.json
- packages/content/src/schema/events.json
- packages/content/src/schema/templates.json
- packages/content/src/schema/options.json
- packages/utils/src/age.ts (yearsBetween, todayISO, dateWhenSiennaWasN)
- packages/utils/src/flags.ts (caregiverMode flag)
- README: adds "Schema readiness" section

Notes:
- Purely additive and inert until UI wires to these schemas.
- JSON uses ISO 8601 dates.
- Multi-select signaled by `{people[]}` in templates.