### PR TITLE
chore(data): pipeline scaffolding + merge/dedupe scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,8 @@ coverage/
 .env
 .env.*
 
+# Data (raw/work are local only)
+data/raw/
+data/work/
+*.numbers
+

--- a/data/config/aliases.csv
+++ b/data/config/aliases.csv
@@ -1,0 +1,7 @@
+alias,canonical
+Mommy,Mommy
+Daddy,Daddy
+Chad Wild Clay,Chad Wild Clay
+Vy Qwaint,Vy Qwaint
+Sienna,You (S)
+

--- a/data/config/orgs.csv
+++ b/data/config/orgs.csv
@@ -1,0 +1,5 @@
+id,name,type
+spy-ninjas,Spy Ninjas,channel
+team-rar,Team RAR,team
+sharer-family,Sharer Family,team
+

--- a/data/config/roles.csv
+++ b/data/config/roles.csv
@@ -1,0 +1,7 @@
+role
+member
+founder
+guest
+musician
+actor
+

--- a/docs/DATA_CLEANUP.md
+++ b/docs/DATA_CLEANUP.md
@@ -1,0 +1,33 @@
+# Data Cleanup & Dedupe Plan (Age Comparison)
+
+Scope: consolidate CSV/Numbers data you collected into a single canonical dataset for people and events.
+
+Steps
+- Inventory sources: list all CSV/Numbers now under `apps/age-comparison/siennas-age-comparison-mvp-html-single-page-test/`.
+- Normalize columns: person name, birthdate (ISO), source, notes.
+- Standardize names: map nicknames/variants to canonical names (e.g., "Mommy" → "Mom").
+- Parse dates: convert to ISO `YYYY-MM-DD`; record original if ambiguous.
+- Dedupe: group by canonical name + birthdate; flag conflicts for review.
+- Export: `people.csv` and `events.csv` at `data/clean/` and JSON mirrors into `packages/content/src/schema/`.
+
+Artifacts
+- data/raw/: untouched exports (CSV)
+- data/work/: intermediate merges (CSV)
+- data/clean/: final `people.csv`, `events.csv`
+
+CLI
+- Create folders and drop raw CSVs into `data/raw/` (copy from your old folders).
+- Run merge/dedupe for people: `python3 scripts/data/people_merge.py`
+- Run merge/dedupe for events: `python3 scripts/data/events_merge.py`
+- Export JSON mirrors: `python3 scripts/data/export_json.py`
+
+Outputs
+- data/work/people_raw.csv – combined rows with canonicalized names
+- data/work/people_review.csv – potential conflicts to review
+- data/clean/people.csv – exact-deduped canonical list
+- data/clean/events.csv – deduped events
+
+Notes
+- Prefer human-verified corrections when conflicts arise.
+- Keep minimal fields now; add optional metadata later (`source_url`, `aka`, `tags`).
+

--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -1,0 +1,28 @@
+# Data Model (Minimal, Extensible)
+
+## People (data/clean/people.csv)
+- id: slug (unique), suggest `name-slug-YYYY`
+- name: canonical display name
+- birth_date: ISO `YYYY-MM-DD` (optional if unknown)
+
+## Events (data/clean/events.csv)
+- id: slug
+- name: label
+- date: ISO `YYYY-MM-DD`
+
+## Orgs (data/config/orgs.csv)
+- id: slug
+- name: label
+- type: channel | team | band | show | other
+
+## Roles (data/config/roles.csv)
+- role: allowed role names
+
+## Memberships (future)
+- person_id, org_id, role, start_date?, end_date?
+
+Notes
+- Raw exports live in `data/raw/` and are not committed.
+- Intermediate results in `data/work/`.
+- Canonical outputs in `data/clean/` and JSON mirrors in `packages/content/src/schema/`.
+

--- a/scripts/data/events_merge.py
+++ b/scripts/data/events_merge.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+import csv, os, glob, sys
+from datetime import datetime
+
+RAW_DIR = os.path.join('data','raw')
+WORK_DIR = os.path.join('data','work')
+CLEAN_DIR = os.path.join('data','clean')
+
+NAME_CANDIDATES = ['event','name','label','title']
+DATE_CANDIDATES = ['date','event_date']
+
+def ensure_dirs():
+  os.makedirs(WORK_DIR, exist_ok=True)
+  os.makedirs(CLEAN_DIR, exist_ok=True)
+
+def pick_col(headers, candidates):
+  lower = [h.lower() for h in headers]
+  for c in candidates:
+    if c in lower:
+      return headers[lower.index(c)]
+  return None
+
+def parse_date(s):
+  if not s: return ''
+  s = s.strip()
+  try:
+    return datetime.strptime(s,'%Y-%m-%d').strftime('%Y-%m-%d')
+  except Exception:
+    pass
+  for fmt in ['%m/%d/%Y','%d/%m/%Y','%b %d, %Y','%B %d, %Y']:
+    try:
+      return datetime.strptime(s,fmt).strftime('%Y-%m-%d')
+    except Exception:
+      continue
+  return ''
+
+def slugify(s):
+  t = ''.join(ch.lower() if ch.isalnum() else '-' for ch in s)
+  while '--' in t: t = t.replace('--','-')
+  return t.strip('-')
+
+def main():
+  ensure_dirs()
+  raw_rows = []
+  files = sorted(glob.glob(os.path.join(RAW_DIR,'*.csv')))
+  if not files:
+    print('No raw CSVs found in data/raw. Place source files there.', file=sys.stderr)
+  for fp in files:
+    with open(fp, newline='', encoding='utf-8') as f:
+      reader = csv.DictReader(f)
+      headers = reader.fieldnames or []
+      name_col = pick_col(headers, NAME_CANDIDATES)
+      date_col = pick_col(headers, DATE_CANDIDATES)
+      if not name_col or not date_col:
+        continue
+      for idx, row in enumerate(reader, start=2):
+        name = (row.get(name_col) or '').strip()
+        if not name: continue
+        d = parse_date(row.get(date_col) or '')
+        raw_rows.append({'name': name, 'date': d})
+
+  # dedupe by (name,date)
+  seen = set(); out = []
+  for r in raw_rows:
+    key = (r['name'].lower(), r['date'])
+    if key in seen: continue
+    seen.add(key)
+    out.append({'id': slugify(r['name']), 'name': r['name'], 'date': r['date']})
+
+  work_csv = os.path.join(WORK_DIR,'events_raw.csv')
+  with open(work_csv,'w', newline='', encoding='utf-8') as f:
+    w = csv.DictWriter(f, fieldnames=['name','date'])
+    w.writeheader(); w.writerows(raw_rows)
+
+  clean_csv = os.path.join(CLEAN_DIR,'events.csv')
+  with open(clean_csv,'w', newline='', encoding='utf-8') as f:
+    w = csv.DictWriter(f, fieldnames=['id','name','date'])
+    w.writeheader(); w.writerows(out)
+
+  print(f"Wrote {work_csv}, {clean_csv}")
+
+if __name__ == '__main__':
+  main()
+

--- a/scripts/data/export_json.py
+++ b/scripts/data/export_json.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+import csv, json, os
+
+CLEAN_DIR = os.path.join('data','clean')
+SCHEMA_DIR = os.path.join('packages','content','src','schema')
+
+def ensure_dirs():
+  os.makedirs(SCHEMA_DIR, exist_ok=True)
+
+def people_csv_to_json():
+  path = os.path.join(CLEAN_DIR,'people.csv')
+  if not os.path.exists(path):
+    return False
+  people = []
+  with open(path, newline='', encoding='utf-8') as f:
+    r = csv.DictReader(f)
+    for row in r:
+      if not row.get('name'): continue
+      dob = row.get('birth_date') or ''
+      people.append({
+        'id': row.get('id') or row['name'],
+        'label': row['name'],
+        'birthDate': dob
+      })
+  out = {"$meta": {"version":1}, "people": people}
+  with open(os.path.join(SCHEMA_DIR,'people.json'),'w', encoding='utf-8') as f:
+    json.dump(out, f, ensure_ascii=False, indent=2)
+  return True
+
+def events_csv_to_json():
+  path = os.path.join(CLEAN_DIR,'events.csv')
+  if not os.path.exists(path):
+    return False
+  events = []
+  with open(path, newline='', encoding='utf-8') as f:
+    r = csv.DictReader(f)
+    for row in r:
+      if not row.get('name'): continue
+      events.append({
+        'id': row.get('id') or row['name'],
+        'label': row['name'],
+        'date': row.get('date') or ''
+      })
+  out = {"$meta": {"version":1}, "events": events}
+  with open(os.path.join(SCHEMA_DIR,'events.json'),'w', encoding='utf-8') as f:
+    json.dump(out, f, ensure_ascii=False, indent=2)
+  return True
+
+def main():
+  ensure_dirs()
+  p = people_csv_to_json()
+  e = events_csv_to_json()
+  print(f"Exported people.json: {p}, events.json: {e}")
+
+if __name__ == '__main__':
+  main()
+

--- a/scripts/data/people_merge.py
+++ b/scripts/data/people_merge.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+import csv, os, glob, sys
+from datetime import datetime
+
+RAW_DIR = os.path.join('data','raw')
+WORK_DIR = os.path.join('data','work')
+CLEAN_DIR = os.path.join('data','clean')
+ALIASES_CSV = os.path.join('data','config','aliases.csv')
+
+NAME_CANDIDATES = [
+  'name','person','full_name','display_name','channel','channel_name','artist','title'
+]
+DOB_CANDIDATES = [
+  'birthdate','birth_date','dob','date_of_birth','birthday','date'
+]
+
+def ensure_dirs():
+  os.makedirs(WORK_DIR, exist_ok=True)
+  os.makedirs(CLEAN_DIR, exist_ok=True)
+
+def load_aliases(path):
+  m = {}
+  if not os.path.exists(path):
+    return m
+  with open(path, newline='', encoding='utf-8') as f:
+    r = csv.DictReader(f)
+    for row in r:
+      alias = (row.get('alias') or '').strip().lower()
+      canon = (row.get('canonical') or '').strip()
+      if alias and canon:
+        m[alias] = canon
+  return m
+
+def pick_col(headers, candidates):
+  lower = [h.lower() for h in headers]
+  for c in candidates:
+    if c in lower:
+      return headers[lower.index(c)]
+  return None
+
+def parse_date(s):
+  if not s: return ''
+  s = s.strip()
+  # already ISO
+  try:
+    dt = datetime.strptime(s, '%Y-%m-%d')
+    return dt.strftime('%Y-%m-%d')
+  except Exception:
+    pass
+  fmts = [
+    '%m/%d/%Y','%d/%m/%Y','%m/%d/%y','%d/%m/%y',
+    '%b %d, %Y','%B %d, %Y','%d %b %Y','%d %B %Y'
+  ]
+  for fmt in fmts:
+    try:
+      dt = datetime.strptime(s, fmt)
+      return dt.strftime('%Y-%m-%d')
+    except Exception:
+      continue
+  return ''
+
+def slugify(s):
+  t = ''.join(ch.lower() if ch.isalnum() else '-' for ch in s)
+  while '--' in t: t = t.replace('--','-')
+  return t.strip('-')
+
+def main():
+  ensure_dirs()
+  aliases = load_aliases(ALIASES_CSV)
+
+  raw_rows = []
+  files = sorted(glob.glob(os.path.join(RAW_DIR,'*.csv')))
+  if not files:
+    print('No raw CSVs found in data/raw. Place source files there.', file=sys.stderr)
+  for fp in files:
+    with open(fp, newline='', encoding='utf-8') as f:
+      reader = csv.DictReader(f)
+      headers = reader.fieldnames or []
+      name_col = pick_col(headers, NAME_CANDIDATES)
+      dob_col = pick_col(headers, DOB_CANDIDATES)
+      if not name_col:
+        print(f"Skip {fp}: no recognizable name column", file=sys.stderr)
+        continue
+      for idx, row in enumerate(reader, start=2):
+        name = (row.get(name_col) or '').strip()
+        if not name: continue
+        dob_raw = (row.get(dob_col) or '').strip() if dob_col else ''
+        dob_iso = parse_date(dob_raw)
+        key_alias = name.strip().lower()
+        canonical = aliases.get(key_alias, name)
+        raw_rows.append({
+          'source_file': os.path.basename(fp),
+          'row': idx,
+          'name': name,
+          'canonical_name': canonical,
+          'birth_date_iso': dob_iso,
+        })
+
+  # write work/people_raw.csv
+  work_csv = os.path.join(WORK_DIR,'people_raw.csv')
+  with open(work_csv, 'w', newline='', encoding='utf-8') as f:
+    w = csv.DictWriter(f, fieldnames=['source_file','row','name','canonical_name','birth_date_iso'])
+    w.writeheader(); w.writerows(raw_rows)
+
+  # exact dedupe by (canonical_name_lower, birth_date_iso)
+  seen = {}
+  out = []
+  for r in raw_rows:
+    key = (r['canonical_name'].strip().lower(), r['birth_date_iso'])
+    if key in seen: continue
+    seen[key] = True
+    base_id = slugify(r['canonical_name'])
+    if r['birth_date_iso']:
+      yr = r['birth_date_iso'][:4]
+      pid = f"{base_id}-{yr}"
+    else:
+      pid = base_id
+    out.append({'id': pid, 'name': r['canonical_name'], 'birth_date': r['birth_date_iso']})
+
+  clean_csv = os.path.join(CLEAN_DIR,'people.csv')
+  with open(clean_csv,'w', newline='', encoding='utf-8') as f:
+    w = csv.DictWriter(f, fieldnames=['id','name','birth_date'])
+    w.writeheader(); w.writerows(out)
+
+  # simple review file: same name different dates, same date different names
+  name_to_dates = {}
+  date_to_names = {}
+  for r in raw_rows:
+    n = r['canonical_name'].strip()
+    d = r['birth_date_iso']
+    if n: name_to_dates.setdefault(n,set()).add(d)
+    if d: date_to_names.setdefault(d,set()).add(n)
+  review_path = os.path.join(WORK_DIR,'people_review.csv')
+  with open(review_path,'w', newline='', encoding='utf-8') as f:
+    w = csv.writer(f)
+    w.writerow(['kind','name_or_date','values'])
+    for n, dates in name_to_dates.items():
+      if len(dates) > 1:
+        w.writerow(['same_name_varied_dates', n, ';'.join(sorted(dates))])
+    for d, names in date_to_names.items():
+      if len(names) > 1:
+        w.writerow(['same_date_varied_names', d, ';'.join(sorted(names))])
+
+  print(f"Wrote {work_csv}, {review_path}, {clean_csv}")
+
+if __name__ == '__main__':
+  main()
+


### PR DESCRIPTION
Adds a minimal, repeatable data pipeline.

Folders
- data/{raw,work,clean,config}

Configs
- data/config/aliases.csv (alias → canonical)
- data/config/orgs.csv, data/config/roles.csv

Scripts
- scripts/data/people_merge.py (normalize + exact dedupe people)
- scripts/data/events_merge.py (normalize + dedupe events)
- scripts/data/export_json.py (export clean CSVs → schema JSON)

Docs
- docs/DATA_MODEL.md
- docs/DATA_CLEANUP.md (CLI steps)

Git
- .gitignore ignores data/raw and data/work

Usage
1) Put raw CSVs in data/raw/
2) python3 scripts/data/people_merge.py
3) python3 scripts/data/events_merge.py
4) python3 scripts/data/export_json.py